### PR TITLE
Changing config approach

### DIFF
--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -79,17 +79,19 @@ function configure_dolphin() {
     local launch_prefix
     isPlatform "kms" && launch_prefix="XINIT-WM:"
 
-    addEmulator 0 "$md_id" "gc" "$launch_prefix$md_inst/bin/dolphin-emu-nogui -e %ROM%"
-    addEmulator 1 "$md_id-gui" "gc" "$launch_prefix$md_inst/bin/dolphin.sh %ROM%"
-    addEmulator 0 "$md_id" "wii" "$launch_prefix$md_inst/bin/dolphin-emu-nogui -e %ROM%"
-    addEmulator 1 "$md_id-gui" "wii" "$launch_prefix$md_inst/bin/dolphin-emu -b -e %ROM%"
+    addEmulator 0 "$md_id" "gc" "$launch_prefix$md_inst/bin/dolphin_launcher.py gc %ROM%"
+    addEmulator 1 "$md_id-bin" "gc" "$launch_prefix$md_inst/bin/dolphin-emu-nogui -e %ROM%"
+    addEmulator 2 "$md_id-gui" "gc" "$launch_prefix$md_inst/bin/dolphin-emu -b -e %ROM%"
+    addEmulator 0 "$md_id" "wii" "$launch_prefix$md_inst/bin/dolphin_launcher.py wii %ROM%"
+    addEmulator 1 "$md_id-bin" "wii" "$launch_prefix$md_inst/bin/dolphin-emu-nogui -e %ROM%"
+    addEmulator 2 "$md_id-gui" "wii" "$launch_prefix$md_inst/bin/dolphin-emu -b -e %ROM%"
 
     addSystem "gc"
     addSystem "wii"
 
     # copy hotkey remapping start script
-    cp "$md_data/dolphin.sh" "$md_inst/bin/"
-    chmod +x "$md_inst/bin/dolphin.sh"
+    cp "$md_data/dolphin_launcher.py" "$md_inst/bin/"
+    chmod +x "$md_inst/bin/dolphin_launcher.py"
 
     [[ "$md_mode" == "remove" ]] && return
 

--- a/scriptmodules/emulators/dolphin/dolphin_launcher.py
+++ b/scriptmodules/emulators/dolphin/dolphin_launcher.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+import argparse
+import configparser
+import pathlib
+import shlex
+import shutil
+import subprocess
+import sys
+import os
+
+import sdl2
+
+# Disable HIDAPI to ensure compatibility with EmulationStation
+os.environ["SDL_JOYSTICK_HIDAPI"] = "0"
+
+configparser.ConfigParser.optionxform = str
+dolphin_config = pathlib.Path("/opt/retropie/configs/gc/Config")
+# dolphin_config = pathlib.Path("/home/golden/.var/app/org.DolphinEmu.dolphin-emu/config/dolphin-emu")
+profile_dirs = {
+    "gc": dolphin_config / "Profiles/GCPad",
+    "wii": dolphin_config / "Profiles/Wiimote",
+}
+section_names = {
+    "gc": "GCPad",
+    "wii": "Wiimote",
+}
+dolphin_keybinds = {
+    "gc": dolphin_config / "GCPadNew.ini",
+    "wii": dolphin_config / "WiimoteNew.ini",
+}
+dolphin_temp_keybinds = {
+    "gc": pathlib.Path("/tmp/GCPadNew.ini"),
+    "wii": pathlib.Path("/tmp/WiimoteNew.ini"),
+}
+
+dolphin_emu = pathlib.Path("/opt/retropie/emulators/dolphin/bin/dolphin-emu")
+dolphin_tool = pathlib.Path("/opt/retropie/emulators/dolphin/bin/dolphin-tool")
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("console", help="Console to use")
+    parser.add_argument("game", help="Game to start")
+
+    return parser.parse_args()
+
+def get_gamepad_config(gamepad_name, profile_type):
+    sanitise_table = dict.fromkeys(map(ord, ':><?"/\\|*'), None)
+    filename = f'{gamepad_name.translate(sanitise_table)}.ini'
+
+    profile_dir = profile_dirs[profile_type]
+    profile_file = profile_dir / filename
+    print(profile_file)
+    if not profile_file.exists():
+        print(f"Profile {filename} not found for {profile_type}")
+        return None
+    config = configparser.ConfigParser()
+    config.read(profile_file)
+    return config['Profile']
+
+def find_game_controllers(profile_type) -> list[dict]:
+    print("Scanning for game controllers...")
+    gamepads: list[dict] = []
+    sdl_cache: list[str] = []
+    # with open("/proc/bus/input/devices") as f:
+        # # evdev_name = ""
+        # sdl_name = ""
+        # js_index = ""
+        # for line in f:
+            # line = line.strip()
+            # # print(line)
+            # if line.startswith("I:"):
+                # evdev_name = ""
+                # sdl_name = ""
+                # js_index = ""
+            # elif line.startswith("N:"):
+                # evdev_name = line.split("Name=")[1].strip()[1:-1]
+            # elif line.startswith("H:") and "js" in line:
+                # js_index = line.split("js")[1].strip()
+                # sdl_name = sdl2.SDL_GameControllerNameForIndex(int(js_index)).decode("utf-8")
+                # c = 0
+                # while True:
+                    # dolphin_name = f'SDL/{c}/{sdl_name}'
+                    # if dolphin_name not in sdl_cache:
+                        # sdl_cache.append(dolphin_name)
+                        # config = get_gamepad_config(evdev_name, profile_type)
+                        # if config is not None:
+                            # gamepads.append((evdev_name, dolphin_name, js_index, config))
+                        # break
+                    # c += 1
+    for i in range(sdl2.SDL_NumJoysticks()):
+        gamepad_name = sdl2.SDL_GameControllerNameForIndex(i).decode("utf-8")
+        js_name = sdl2.SDL_JoystickNameForIndex(i).decode("utf-8")
+        c = 0
+        while True:
+            dolphin_name = f'SDL/{c}/{gamepad_name}'
+            if dolphin_name not in sdl_cache:
+                sdl_cache.append(dolphin_name)
+                config = get_gamepad_config(js_name, profile_type)
+                if config is not None:
+                    gamepads.append({
+                        'name': dolphin_name,
+                        'config': config})
+                break
+            c += 1
+    print(gamepads)
+    return gamepads
+
+def create_new_config(gamepads, console):
+    new_config = configparser.ConfigParser()
+    for i, gamepad in enumerate(gamepads, start=1):
+        controller_config = gamepad['config']
+        controller_config['Device'] = gamepad['name']
+        controller_config['Source'] = '1'
+        new_config[f'{section_names[console]}{i}'] = controller_config
+    #with open("new.ini", "w") as f:
+    #    new_config.write(f)
+    return new_config
+
+def create_empty_config(console):
+    new_config = configparser.ConfigParser()
+    for i in range(1, 5):
+        new_config[f'{section_names[console]}{i}'] = {"Source": "0"}
+    return new_config
+
+def start_game(game, selected_console, config):
+    try:
+        for console in dolphin_keybinds:
+            if dolphin_keybinds[console].exists():
+                shutil.move(dolphin_keybinds[console], dolphin_temp_keybinds[console])
+            with open(dolphin_keybinds[console], "w") as f:
+                if console == selected_console:
+                    print(f"Writing new keybinds at {dolphin_keybinds[selected_console]}")
+                    config.write(f)
+                else:
+                    print(f"Writing empty keybinds at {dolphin_keybinds[console]}")
+                    create_empty_config(console).write(f)
+        launch_cmd = f'{dolphin_emu} -b -e "{game}"'
+        proc = subprocess.Popen(shlex.split(launch_cmd))
+        proc.wait()
+    finally:
+        print("Restoring original keybinds")
+        for console in dolphin_keybinds:
+            if dolphin_temp_keybinds[console].exists():
+                shutil.move(dolphin_temp_keybinds[console], dolphin_keybinds[console])
+
+def main(rom, selected_console):
+    sdl2.SDL_Init(sdl2.SDL_INIT_JOYSTICK | sdl2.SDL_INIT_GAMECONTROLLER)
+    gamepads = find_game_controllers(selected_console)
+    new_config = create_new_config(gamepads, selected_console)
+    start_game(rom, selected_console, new_config)
+
+if __name__ == "__main__":
+    args = get_args()
+    print(args)
+    main(args.game, args.console)

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -79,35 +79,35 @@ function map_dolphin_joystick() {
             ;;
         b)
             gc_keys=("Buttons/B")
-            wii_keys=("Buttons/B" "Classic/Buttons/A")
+            wii_keys=("Buttons/A" "Classic/Buttons/A")
             is_b=true
             ;;
         y)
             gc_keys=("Buttons/Y")
-            wii_keys=("Buttons/2" "Classic/Buttons/X")
+            wii_keys=("Buttons/1" "Classic/Buttons/X")
             ;;
         a)
             gc_keys=("Buttons/A")
-            wii_keys=("Buttons/A" "Classic/Buttons/B")
+            wii_keys=("Buttons/B" "Classic/Buttons/B")
             is_a=true
             ;;
         x)
             gc_keys=("Buttons/X")
-            wii_keys=("Buttons/1" "Classic/Buttons/Y")
+            wii_keys=("Buttons/2" "Classic/Buttons/Y")
             ;;
         leftbottom|leftshoulder)
-            gc_keys=("Triggers/L")
             wii_keys=("Nunchuk/Buttons/C" "Classic/Buttons/ZL")
             ;;
         rightbottom|rightshoulder)
-            gc_keys=("Triggers/R")
+            gc_keys=("Buttons/Z")
             wii_keys=("Shake/X" "Shake/Y" "Shake/Z" "Classic/Buttons/ZR")
             ;;
         righttop|righttrigger)
-            gc_keys=("Buttons/Z")
+            gc_keys=("Triggers/R")
             wii_keys=("Nunchuk/Shake/X" "Nunchuk/Shake/Y" "Nunchuk/Shake/Z" "Classic/Buttons/R-Analog")
             ;;
         lefttop|lefttrigger)
+            gc_keys=("Triggers/L")
             wii_keys=("Nunchuk/Buttons/Z" "Classic/Buttons/L-Analog")
             ;;
         start)

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -79,21 +79,21 @@ function map_dolphin_joystick() {
             ;;
         b)
             gc_keys=("Buttons/B")
-            wii_keys=("Buttons/A" "Classic/Buttons/A")
+            wii_keys=("Buttons/A" "Classic/Buttons/B")
             is_b=true
             ;;
         y)
             gc_keys=("Buttons/Y")
-            wii_keys=("Buttons/1" "Classic/Buttons/X")
+            wii_keys=("Buttons/1" "Classic/Buttons/Y")
             ;;
         a)
             gc_keys=("Buttons/A")
-            wii_keys=("Buttons/B" "Classic/Buttons/B")
+            wii_keys=("Buttons/B" "Classic/Buttons/A")
             is_a=true
             ;;
         x)
             gc_keys=("Buttons/X")
-            wii_keys=("Buttons/2" "Classic/Buttons/Y")
+            wii_keys=("Buttons/2" "Classic/Buttons/X")
             ;;
         leftbottom|leftshoulder)
             wii_keys=("Nunchuk/Buttons/C" "Classic/Buttons/ZL")

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -114,6 +114,9 @@ function map_dolphin_joystick() {
             gc_keys=("Buttons/Start")
             wii_keys=("Buttons/+" "Classic/Buttons/+")
             ;;
+        select)
+            wii_keys=("Buttons/-" "Classic/Buttons/-")
+            ;;
         leftanalogleft)
             gc_keys=("Main Stick/Left")
             wii_keys=("Nunchuk/Left" "Classic/Left Stick/Left")

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -104,11 +104,11 @@ function map_dolphin_joystick() {
             ;;
         righttop|righttrigger)
             gc_keys=("Triggers/R")
-            wii_keys=("Nunchuk/Shake/X" "Nunchuk/Shake/Y" "Nunchuk/Shake/Z" "Classic/Buttons/R-Analog")
+            wii_keys=("Nunchuk/Shake/X" "Nunchuk/Shake/Y" "Nunchuk/Shake/Z" "Classic/Triggers/R-Analog")
             ;;
         lefttop|lefttrigger)
             gc_keys=("Triggers/L")
-            wii_keys=("Nunchuk/Buttons/Z" "Classic/Buttons/L-Analog")
+            wii_keys=("Nunchuk/Buttons/Z" "Classic/Triggers/L-Analog")
             ;;
         start)
             gc_keys=("Buttons/Start")

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -137,6 +137,9 @@ function map_dolphin_joystick() {
             wii_keys=("Nunchuk/Down" "Classic/Left Stick/Down")
             dir=("S")
             ;;
+        leftthumb)
+            wii_keys=("Hotkeys/Sideways Toggle")
+            ;;
         rightanalogleft)
             gc_keys=("C-Stick/Left")
             wii_keys=("IR/Left" "Classic/Right Stick/Left")

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -60,22 +60,22 @@ function map_dolphin_joystick() {
         up)
             gc_keys=("D-Pad/Up")
             wii_keys=("D-Pad/Up" "Classic/D-Pad/Up")
-            dir=("Up")
+            dir=("N")
             ;;
         down)
             gc_keys=("D-Pad/Down")
             wii_keys=("D-Pad/Down" "Classic/D-Pad/Down")
-            dir=("Down")
+            dir=("S")
             ;;
         left)
             gc_keys=("D-Pad/Left")
             wii_keys=("D-Pad/Left" "Classic/D-Pad/Left")
-            dir=("Left")
+            dir=("W")
             ;;
         right)
             gc_keys=("D-Pad/Right")
             wii_keys=("D-Pad/Right" "Classic/D-Pad/Right")
-            dir=("Right")
+            dir=("E")
             ;;
         b)
             gc_keys=("Buttons/B")
@@ -120,42 +120,42 @@ function map_dolphin_joystick() {
         leftanalogleft)
             gc_keys=("Main Stick/Left")
             wii_keys=("Nunchuk/Left" "Classic/Left Stick/Left")
-            dir=("Left")
+            dir=("W")
             ;;
         leftanalogright)
             gc_keys=("Main Stick/Right")
             wii_keys=("Nunchuk/Right" "Classic/Left Stick/Right")
-            dir=("Right")
+            dir=("E")
             ;;
         leftanalogup)
             gc_keys=("Main Stick/Up")
             wii_keys=("Nunchuk/Up" "Classic/Left Stick/Up")
-            dir=("Up")
+            dir=("N")
             ;;
         leftanalogdown)
             gc_keys=("Main Stick/Down")
             wii_keys=("Nunchuk/Down" "Classic/Left Stick/Down")
-            dir=("Down")
+            dir=("S")
             ;;
         rightanalogleft)
             gc_keys=("C-Stick/Left")
             wii_keys=("IR/Left" "Classic/Right Stick/Left")
-            dir=("Left")
+            dir=("W")
             ;;
         rightanalogright)
             gc_keys=("C-Stick/Right")
             wii_keys=("IR/Right" "Classic/Right Stick/Right")
-            dir=("Right")
+            dir=("E")
             ;;
         rightanalogup)
             gc_keys=("C-Stick/Up")
             wii_keys=("IR/Up" "Classic/Right Stick/Up")
-            dir=("Up")
+            dir=("N")
             ;;
         rightanalogdown)
             gc_keys=("C-Stick/Down")
             wii_keys=("IR/Down" "Classic/Right Stick/Down")
-            dir=("Down")
+            dir=("S")
             ;;
         hotkeyenable)
             gc_keys=("Hotkey")
@@ -226,9 +226,9 @@ function translate_dolphin_value() {
                     value="${ini_value}\`Hat ${input_id} ${dir}\`"
                 elif [[ "$ini_value" == *\)* ]]; then
                     value="\`Hat ${input_id} ${dir}\`, ${ini_value}"
-                elif [[ "$dir" == "Up" || "$dir" == "Left" ]]; then
+                elif [[ "$dir" == "N" || "$dir" == "W" ]]; then
                     value="\`Hat ${input_id} ${dir}\`"
-                elif [[ "$dir" == "Right" || "$dir" == "Down" ]]; then
+                elif [[ "$dir" == "E" || "$dir" == "S" ]]; then
                     value="\`${dir}\`"
                 fi
             else
@@ -243,9 +243,9 @@ function translate_dolphin_value() {
                     value="${ini_value}\`Button ${input_id}\`"
                 elif [[ "$ini_value" == *\)* ]]; then
                     value="\`Button ${input_id}\`, ${ini_value}"
-                elif [[ "$dir" == "Up" || "$dir" == "Left" ]]; then
+                elif [[ "$dir" == "N" || "$dir" == "W" ]]; then
                     value="\`Button ${input_id}\`"
-                elif [[ "$dir" == "Right" || "$dir" == "Down" ]]; then
+                elif [[ "$dir" == "E" || "$dir" == "S" ]]; then
                     value="\`${input_id}\`"
                 fi
             else

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -284,7 +284,7 @@ function onend_dolphin_joystick() {
             fi
         done
     fi
-    
+
     # Map generic Stick cali
     cat <<EOF >> ${_tmp_config_files[gc]}
 Main Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -8,101 +8,156 @@
 # See the LICENSE.md file at the top-level directory of this distribution and
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
+declare -A _tmp_config_files=(
+    [gc]="/tmp/gctempconfig.cfg"
+    [wii]="/tmp/wiitempconfig.cfg"
+)
+declare -A _config_dirs=(
+    [gc]="$configdir/gc/Config/Profiles/GCPad"
+    [wii]="$configdir/gc/Config/Profiles/Wiimote"
+)
+
+_extension_string='Extension = $s=if(pulse(GUIDE,0.3)&pulse(A_BUTTON,0.1),if($s<2&$s>0,0,1),if(pulse(GUIDE,0.3)&pulse(B_BUTTON,0.1),if($s<3&$s>1,0,2),$s))'
 
 function onstart_dolphin_joystick() {
     # write a temp file that will become the Controller Profile
-    iniConfig " = " "" "/tmp/gctempconfig.cfg"
-    cat <<EOF > /tmp/gctempconfig.cfg
+    #
+    for _tmp_filename in "${_tmp_config_files[@]}"; do
+        if [[ -f "$_tmp_filename" ]]; then
+            rm "$_tmp_filename"
+        fi
+        #iniConfig " = " "" "$_tmp_config_file"
+        cat <<EOF > "$_tmp_filename"
 [Profile]
-Device = evdev/0/${DEVICE_NAME}
 EOF
+    done
+
+    #check if file exists
+    if [[ ! -f "${_tmp_config_files[gc]}" ]]; then
+        echo "Failed to create ${_tmp_config_files[gc]}"
+    fi
+    if [[ ! -f "${_tmp_config_files[wii]}" ]]; then
+        echo "Failed to create ${_tmp_config_files[wii]}"
+    fi
 }
 
 
 function map_dolphin_joystick() {
-    local file="/tmp/gctempconfig.cfg"
     local input_name="$1"
     local input_type="$2"
     local input_id="$3"
     local input_value="$4"
 
-    local keys
+    local gc_keys
+    local wii_keys
     local dir
+
+
+    local is_guide
+    local is_a
+    local is_b
     case "$input_name" in
         up)
-            keys=("D-Pad/Up")
+            gc_keys=("D-Pad/Up")
+            wii_keys=("D-Pad/Up" "Classic/D-Pad/Up")
             dir=("Up")
             ;;
         down)
-            keys=("D-Pad/Down")
+            gc_keys=("D-Pad/Down")
+            wii_keys=("D-Pad/Down" "Classic/D-Pad/Down")
             dir=("Down")
             ;;
         left)
-            keys=("D-Pad/Left")
+            gc_keys=("D-Pad/Left")
+            wii_keys=("D-Pad/Left" "Classic/D-Pad/Left")
             dir=("Left")
             ;;
         right)
-            keys=("D-Pad/Right")
+            gc_keys=("D-Pad/Right")
+            wii_keys=("D-Pad/Right" "Classic/D-Pad/Right")
             dir=("Right")
             ;;
         b)
-            keys=("Buttons/B")
+            gc_keys=("Buttons/B")
+            wii_keys=("Buttons/B" "Classic/Buttons/A")
+            is_b=true
             ;;
         y)
-            keys=("Buttons/Y")
+            gc_keys=("Buttons/Y")
+            wii_keys=("Buttons/2" "Classic/Buttons/X")
             ;;
         a)
-            keys=("Buttons/A")
+            gc_keys=("Buttons/A")
+            wii_keys=("Buttons/A" "Classic/Buttons/B")
+            is_a=true
             ;;
         x)
-            keys=("Buttons/X")
+            gc_keys=("Buttons/X")
+            wii_keys=("Buttons/1" "Classic/Buttons/Y")
             ;;
         leftbottom|leftshoulder)
-            keys=("Triggers/L")
+            gc_keys=("Triggers/L")
+            wii_keys=("Nunchuk/Buttons/C" "Classic/Buttons/ZL")
             ;;
         rightbottom|rightshoulder)
-            keys=("Triggers/R")
+            gc_keys=("Triggers/R")
+            wii_keys=("Shake/X" "Shake/Y" "Shake/Z" "Classic/Buttons/ZR")
             ;;
         righttop|righttrigger)
-            keys=("Buttons/Z")
+            gc_keys=("Buttons/Z")
+            wii_keys=("Nunchuk/Shake/X" "Nunchuk/Shake/Y" "Nunchuk/Shake/Z" "Classic/Buttons/R-Analog")
+            ;;
+        lefttop|lefttrigger)
+            wii_keys=("Nunchuk/Buttons/Z" "Classic/Buttons/L-Analog")
             ;;
         start)
-            keys=("Buttons/Start")
+            gc_keys=("Buttons/Start")
+            wii_keys=("Buttons/+" "Classic/Buttons/+")
             ;;
         leftanalogleft)
-            keys=("Main Stick/Left")
+            gc_keys=("Main Stick/Left")
+            wii_keys=("Nunchuk/Left" "Classic/Left Stick/Left")
             dir=("Left")
             ;;
         leftanalogright)
-            keys=("Main Stick/Right")
+            gc_keys=("Main Stick/Right")
+            wii_keys=("Nunchuk/Right" "Classic/Left Stick/Right")
             dir=("Right")
             ;;
         leftanalogup)
-            keys=("Main Stick/Up")
+            gc_keys=("Main Stick/Up")
+            wii_keys=("Nunchuk/Up" "Classic/Left Stick/Up")
             dir=("Up")
             ;;
         leftanalogdown)
-            keys=("Main Stick/Down")
+            gc_keys=("Main Stick/Down")
+            wii_keys=("Nunchuk/Down" "Classic/Left Stick/Down")
             dir=("Down")
             ;;
         rightanalogleft)
-            keys=("C-Stick/Left")
+            gc_keys=("C-Stick/Left")
+            wii_keys=("IR/Left" "Classic/Right Stick/Left")
             dir=("Left")
             ;;
         rightanalogright)
-            keys=("C-Stick/Right")
+            gc_keys=("C-Stick/Right")
+            wii_keys=("IR/Right" "Classic/Right Stick/Right")
             dir=("Right")
             ;;
         rightanalogup)
-            keys=("C-Stick/Up")
+            gc_keys=("C-Stick/Up")
+            wii_keys=("IR/Up" "Classic/Right Stick/Up")
             dir=("Up")
             ;;
         rightanalogdown)
-            keys=("C-Stick/Down")
+            gc_keys=("C-Stick/Down")
+            wii_keys=("IR/Down" "Classic/Right Stick/Down")
             dir=("Down")
             ;;
         hotkeyenable)
-            keys=("Hotkey")
+            gc_keys=("Hotkey")
+            wii_keys=("Buttons/Home" "Classic/Buttons/Home")
+            is_guide=true
             ;;
         *)
             return
@@ -111,68 +166,91 @@ function map_dolphin_joystick() {
 
     local key
     local value
-    #iniConfig " = " "" "/tmp/gckeys.cfg"
-    for key in "${keys[@]}"; do
-        # read key value. Axis takes two key/axis values.
-        iniGet "$key"
-        case "$input_type" in
-            axis)
-                # key "X/Y Axis" needs different button naming
-                if [[ "$key" == *Axis* ]]; then
-                    # if there is already a "-" axis add "+" axis value
-                    if [[ "$ini_value" == *\(* ]]; then
-                        value="${ini_value}\`Axis ${input_id}+\`"
-                    # if there is already a "+" axis add "-" axis value
-                    elif [[ "$ini_value" == *\)* ]]; then
-                        value="\`Axis ${input_id}-\`, ${ini_value}"
-                    # if there is no ini_value add "+" axis value
-                    elif [[ "$input_value" == "1" ]]; then
-                        value="\`Axis ${input_id}+\`"
-                    else
-                        value="\`Axis ${input_id}-\`"
-                    fi
-                elif [[ "$input_value" == "1" ]]; then
-                    value="\`Axis ${input_id}+\` ${ini_value}"
-                else
-                    value="\`Axis ${input_id}-\` ${ini_value}"
-                fi
-                ;;
-            hat)
-                if [[ "$key" == *Axis* ]]; then
-                    if [[ "$ini_value" == *\(* ]]; then
-                        value="${ini_value}\`Hat ${input_id} ${dir}\`"
-                    elif [[ "$ini_value" == *\)* ]]; then
-                        value="\`Hat ${input_id} ${dir}\`, ${ini_value}"
-                    elif [[ "$dir" == "Up" || "$dir" == "Left" ]]; then
-                        value="\`Hat ${input_id} ${dir}\`"
-                    elif [[ "$dir" == "Right" || "$dir" == "Down" ]]; then
-                        value="\`${dir}\`"
-                    fi
-                else
-                    if [[ -n "$dir" ]]; then
-                        value="\`Hat ${input_id} ${dir}\` ${ini_value}"
-                    fi
-                fi
-                ;;
-            *)
-                if [[ "$key" == *Axis* ]]; then
-                    if [[ "$ini_value" == *\(* ]]; then
-                        value="${ini_value}\`Button ${input_id}\`"
-                    elif [[ "$ini_value" == *\)* ]]; then
-                        value="\`Button ${input_id}\`, ${ini_value}"
-                    elif [[ "$dir" == "Up" || "$dir" == "Left" ]]; then
-                        value="\`Button ${input_id}\`"
-                    elif [[ "$dir" == "Right" || "$dir" == "Down" ]]; then
-                        value="\`${input_id}\`"
-                    fi
-                else
-                    value="\`Button ${input_id}\` ${ini_value}"
-                fi
-                ;;
-        esac
 
+    iniConfig " = " "" "${_tmp_config_files[gc]}"
+    for key in "${gc_keys[@]}"; do
+        # read key value. Axis takes two key/axis values.
+        value=$(translate_dolphin_value "$input_name" "$input_type" "$input_id" "$input_value" "$key")
         iniSet "$key" "$value"
     done
+    iniConfig " = " "" "${_tmp_config_files[wii]}"
+    for key in "${wii_keys[@]}"; do
+        value=$(translate_dolphin_value "$input_name" "$input_type" "$input_id" "$input_value" "$key")
+        iniSet "$key" "$value"
+    done
+
+    if [[ "$is_guide" == "true" ]]; then
+        _extension_string="${_extension_string/GUIDE/$value}"
+    elif [[ "$is_a" == "true" ]]; then
+        _extension_string="${_extension_string/A_BUTTON/$value}"
+    elif [[ "$is_b" == "true" ]]; then
+        _extension_string="${_extension_string/B_BUTTON/$value}"
+    fi
+}
+
+function translate_dolphin_value() {
+    local input_name="$1"
+    local input_type="$2"
+    local input_id="$3"
+    local input_value="$4"
+    local key="$5"
+    iniGet "$key"
+    case "$input_type" in
+        axis)
+            # key "X/Y Axis" needs different button naming
+            if [[ "$key" == *Axis* ]]; then
+                # if there is already a "-" axis add "+" axis value
+                if [[ "$ini_value" == *\(* ]]; then
+                    value="${ini_value}\`Axis ${input_id}+\`"
+                # if there is already a "+" axis add "-" axis value
+                elif [[ "$ini_value" == *\)* ]]; then
+                    value="\`Axis ${input_id}-\`, ${ini_value}"
+                # if there is no ini_value add "+" axis value
+                elif [[ "$input_value" == "1" ]]; then
+                    value="\`Axis ${input_id}+\`"
+                else
+                    value="\`Axis ${input_id}-\`"
+                fi
+            elif [[ "$input_value" == "1" ]]; then
+                value="\`Axis ${input_id}+\` ${ini_value}"
+            else
+                value="\`Axis ${input_id}-\` ${ini_value}"
+            fi
+            ;;
+        hat)
+            if [[ "$key" == *Axis* ]]; then
+                if [[ "$ini_value" == *\(* ]]; then
+                    value="${ini_value}\`Hat ${input_id} ${dir}\`"
+                elif [[ "$ini_value" == *\)* ]]; then
+                    value="\`Hat ${input_id} ${dir}\`, ${ini_value}"
+                elif [[ "$dir" == "Up" || "$dir" == "Left" ]]; then
+                    value="\`Hat ${input_id} ${dir}\`"
+                elif [[ "$dir" == "Right" || "$dir" == "Down" ]]; then
+                    value="\`${dir}\`"
+                fi
+            else
+                if [[ -n "$dir" ]]; then
+                    value="\`Hat ${input_id} ${dir}\` ${ini_value}"
+                fi
+            fi
+            ;;
+        *)
+            if [[ "$key" == *Axis* ]]; then
+                if [[ "$ini_value" == *\(* ]]; then
+                    value="${ini_value}\`Button ${input_id}\`"
+                elif [[ "$ini_value" == *\)* ]]; then
+                    value="\`Button ${input_id}\`, ${ini_value}"
+                elif [[ "$dir" == "Up" || "$dir" == "Left" ]]; then
+                    value="\`Button ${input_id}\`"
+                elif [[ "$dir" == "Right" || "$dir" == "Down" ]]; then
+                    value="\`${input_id}\`"
+                fi
+            else
+                value="\`Button ${input_id}\` ${ini_value}"
+            fi
+            ;;
+    esac
+    echo "$value" | awk '{$1=$1};1'
 }
 
 function onend_dolphin_joystick() {
@@ -180,7 +258,7 @@ function onend_dolphin_joystick() {
     local dpad_axis
 
     # Check if any Main Stick entries exist
-    if ! grep -q "Main Stick" /tmp/gctempconfig.cfg; then
+    if ! grep -q "Main Stick" ${_tmp_config_files[gc]}; then
         # List of D-Pad to Main Stick mappings
         declare -A axis_mapping=(
             ["D-Pad/Up"]="Main Stick/Up"
@@ -192,7 +270,7 @@ function onend_dolphin_joystick() {
         # Loop through the D-Pad mappings and rename them
         for dpad_axis in "${!axis_mapping[@]}"; do
             # Check if the D-Pad entry exists
-            if grep -q "$dpad_axis" /tmp/gctempconfig.cfg; then
+            if grep -q "$dpad_axis" ${_tmp_config_files[gc]}; then
                 # Get the value for the D-Pad entry
                 iniGet "$dpad_axis"
                 ini_value="$ini_value"
@@ -205,23 +283,30 @@ function onend_dolphin_joystick() {
     fi
     
     # Map generic Stick cali
-    cat <<EOF >> /tmp/gctempconfig.cfg
+    cat <<EOF >> ${_tmp_config_files[gc]}
 Main Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42
 C-Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42
 EOF
-    
+
+    cat <<EOF >> ${_tmp_config_files[wii]}
+${_extension_string}
+EOF
+
     # disable any auto configs for the same device to avoid duplicates
     local output_file
-    local dir="$configdir/gc/Config/Profiles/GCPad"
-    while read -r output_file; do
-        mv "$output_file" "$output_file.bak"
-    done < <(grep -Fl "\"$DEVICE_NAME\"" "$dir/"*.ini 2>/dev/null)
+    for dir in "${_config_dirs[@]}"; do
+        while read -r output_file; do
+            mv "$output_file" "$output_file.bak"
+        done < <(grep -Fl "\"$DEVICE_NAME\"" "$dir/"*.ini 2>/dev/null)
+        # sanitise filename
+        output_file="${DEVICE_NAME//[:><?\"\/\\|*]/}.ini"
 
-    # sanitise filename
-    output_file="${DEVICE_NAME//[:><?\"\/\\|*]/}.ini"
+        if [[ -f "$dir/$output_file" ]]; then
+            mv "$dir/$output_file" "$dir/$output_file.bak"
+        fi
+    done
 
-    if [[ -f "$dir/$output_file" ]]; then
-        mv "$dir/$output_file" "$dir/$output_file.bak"
-    fi
-    mv "/tmp/gctempconfig.cfg" "$dir/$output_file"
+    mv "${_tmp_config_files[gc]}" "${_config_dirs[gc]}/$output_file"
+    mv "${_tmp_config_files[wii]}" "${_config_dirs[wii]}/$output_file"
+
 }

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -183,11 +183,11 @@ function map_dolphin_joystick() {
     done
 
     if [[ "$is_guide" == "true" ]]; then
-        _extension_string="${_extension_string/GUIDE/$value}"
+        _extension_string="${_extension_string//GUIDE/$value}"
     elif [[ "$is_a" == "true" ]]; then
-        _extension_string="${_extension_string/A_BUTTON/$value}"
+        _extension_string="${_extension_string//A_BUTTON/$value}"
     elif [[ "$is_b" == "true" ]]; then
-        _extension_string="${_extension_string/B_BUTTON/$value}"
+        _extension_string="${_extension_string//B_BUTTON/$value}"
     fi
 }
 

--- a/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/dolphin.sh
@@ -291,11 +291,20 @@ function onend_dolphin_joystick() {
     # Map generic Stick cali
     cat <<EOF >> ${_tmp_config_files[gc]}
 Main Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42
+Main Stick/Dead Zone = 15.
 C-Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42
+C-Stick/Dead Zone = 15.
+
 EOF
 
     cat <<EOF >> ${_tmp_config_files[wii]}
 ${_extension_string}
+IR/Relative Input = True
+Classic/Left Stick/Dead Zone = 15.
+Classic/Right Stick/Dead Zone = 15.
+Nunchuk/Stick/Dead Zone = 15.
+IR/Dead Zone = 15.
+
 EOF
 
     # disable any auto configs for the same device to avoid duplicates


### PR DESCRIPTION
Since I strongly believe in my approach to solve the SDL naming and mapping confusion and also prevent the recent .m3u issues, I'd like you to have a look to this script. Instead of creating profiles with fixed gamepads (not working if you have more than one gamepad with the same name), generate a profile where the device name can be appended on the fly after checking at start time the list of connected controllers.

Supports also switching Wiimote setup (only Wiimote, Sideways Wiimote, Classic Controller and Wiimote+Nunchuk at the moment).

With this, the P1 will also be able to quit the game by pressing Guide+A+B

Of course we still need to address keyboard configurations, but I think gamepads have the priority at the moment.

==== THE FOLLOWING HAS BEEN WRITTEN BY COPILOT (I wanted to try it out, and it seems it's working fine)

This pull request includes significant changes to the Dolphin emulator configuration and joystick mapping scripts. The main focus is on introducing a new Python launcher script for Dolphin, updating the emulator configuration in `dolphin.sh`, and enhancing the joystick mapping logic in `emulationstation/configscripts/dolphin.sh`.

### Emulator Configuration Changes:
* Updated the `configure_dolphin` function to use `dolphin_launcher.py` for launching games, and adjusted the emulator entries accordingly.
* Replaced the hotkey remapping script `dolphin.sh` with `dolphin_launcher.py`.

### New Python Launcher Script:
* Added `dolphin_launcher.py` which handles game launching, controller configuration, and hotkey management. This script uses SDL2 for game controller detection and configparser for managing configuration files.

### Joystick Mapping Enhancements:
* Introduced temporary configuration files and directories for GameCube and Wii controllers in `emulationstation/configscripts/dolphin.sh`.
* Enhanced the `map_dolphin_joystick` function to support both GameCube and Wii controllers, including new key mappings and translation logic for input values. [[1]](diffhunk://#diff-e1133b911ec3a4aedee0387042e0ec0eb7e4ac86cff05ff1711a7ac018d50de2L114-R202) [[2]](diffhunk://#diff-e1133b911ec3a4aedee0387042e0ec0eb7e4ac86cff05ff1711a7ac018d50de2L146-R234) [[3]](diffhunk://#diff-e1133b911ec3a4aedee0387042e0ec0eb7e4ac86cff05ff1711a7ac018d50de2L163-R267)
* Updated the `onend_dolphin_joystick` function to handle the new configuration files and apply additional joystick calibration settings. [[1]](diffhunk://#diff-e1133b911ec3a4aedee0387042e0ec0eb7e4ac86cff05ff1711a7ac018d50de2L195-R279) [[2]](diffhunk://#diff-e1133b911ec3a4aedee0387042e0ec0eb7e4ac86cff05ff1711a7ac018d50de2L208-R326)